### PR TITLE
pc - add workflow to build storybook and publish to GitHub pages

### DIFF
--- a/.github/workflows/publish-storybook-to-github-pages.yml
+++ b/.github/workflows/publish-storybook-to-github-pages.yml
@@ -1,0 +1,29 @@
+# Adapted from https://dev.to/kouts/deploy-storybook-to-github-pages-3bij
+
+name: Publish Storybook to GitHub Pages
+on: 
+  push:
+    branches:
+      - main
+    paths: ["javascript/src/stories/**", "javascript/src/main/**","javascript/.storybook/**",".github/workflows/publish-storybook-to-github-pages.yml"] # Trigger the action only when files change in the folders defined here
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+      - name: Install and Build 🔧
+        run: | # Install npm packages and build the Storybook files
+          cd javascript
+          npm install
+          npm run build-storybook
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@3.6.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: main # The branch the action should deploy to.
+          FOLDER: javascript/docs-build # The folder that the build-storybook script generates files.
+          CLEAN: true # Automatically remove deleted files from the deploy branch
+          TARGET_FOLDER: docs/storybook # The folder that we serve our Storybook files from

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ package-lock.json
 # Don't check in a built storybook
 
 javascript/storybook-static
+javascript/docs-build
 
 # No emacs backup files
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,4 @@
+---
+---
+
+* [Storybook](storybook): Gallery of React Components

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -29,7 +29,7 @@
     "coverage": "react-scripts test --env=jsdom-fourteen --coverage --watchAll=false",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006 -s public",
-    "build-storybook": "build-storybook -s public"
+    "build-storybook": "build-storybook -o docs-build"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
Converted to draft since we may use a different approach; namely either putting the storybook in a separate branch, or in a separate repo.  Stay tuned.

In this PR, we add a GitHub actions workflow that will publish the storybook to GitHub pages.

Together with this PR, it is necessary to set up GitHub pages on the `main` branch with `/docs` as the default folder.

Note that the secret used in the workflow, i.e. `GITHUB_TOKEN`, does *not* need to be defined in the secrets for the repo or the organization; `GITHUB_TOKEN` is a special value that is available in all GitHub Actions workflows (see: https://docs.github.com/en/actions/reference/authentication-in-a-workflow)

Workflow is only triggered when changes are made to `javascript/src/main`, `javascript/src/stories` `javascript/.storybook` or to the workflow itself.

In the docs folder, we add an `index.md` written in GitHub Flavored Markdown and setup for Jekyll (with two lines of `---` at the top; between these two lines, "front matter" for Jekyll can be defined if needed.   The `index.md` file contains a link to th storybook, but could have additional links in it later if desired (e.g. if we set up a workflow for javadoc or code coverage reports, for example.)