### PR TITLE
pc - update codecov badge in README.md to s21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ucsb-courses-search
 
-[![codecov](https://codecov.io/gh/ucsb-cs156-f20/proj-ucsb-courses-search/branch/main/graph/badge.svg)](https://codecov.io/gh/ucsb-cs156-f20/proj-ucsb-courses-search)
+[![codecov](https://codecov.io/gh/ucsb-cs156-s21/proj-ucsb-courses-search/branch/main/graph/badge.svg?token=oRuQrNWHMx)](https://codecov.io/gh/ucsb-cs156-s21/proj-ucsb-courses-search)
 
 ## Purpose
 


### PR DESCRIPTION
In this PR, we update the codecov badge in the README.md to point to s21 instead of f20.

The codecov badge looked like this before this PR:

<img width="461" alt="image" src="https://user-images.githubusercontent.com/1119017/115975427-8c354980-a519-11eb-8f91-eaefc8441647.png">

And is produced by code like this in the README.md:

```
[![codecov](https://codecov.io/gh/ucsb-cs156-f20/proj-ucsb-courses-search/branch/main/graph/badge.svg)](https://codecov.io/gh/ucsb-cs156-f20/proj-ucsb-courses-search)
```

We updated `f20` to `s21` since the repo has been moved (twice actually, from ucsb-cs156-f20 to ucsb-cs156-w21, then to ucsb-cs156-s21).   We also added a token (we went to the Codecov page for repo to get the updated code for the badge; we didn't just change the f20 to s21).

After then merging a PR with an empty commit ( to trigger a baseline build for codecov), the logo for this branch now shows the 100% badge and links properly to Codecov:

<img width="496" alt="image" src="https://user-images.githubusercontent.com/1119017/115977138-01107f80-a52a-11eb-928b-f29e7d9b0b07.png">
