### PR TITLE
pc - move copy of React app into deploy phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
 				<version>3.0.0</version>
 				<executions>
 					<execution>
-						<phase>generate-resources</phase>
+						<phase>deploy</phase>
 						<configuration>
 							<target combine.children="append">
 								<mkdir dir="${project.basedir}/javascript/build" />

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
 				<version>3.0.0</version>
 				<executions>
 					<execution>
-						<phase>deploy</phase>
+						<phase>process-resources</phase>
 						<configuration>
 							<target >
 								<mkdir dir="${project.basedir}/javascript/build" />
@@ -330,6 +330,7 @@
 						</configuration>
 						<executions>
 							<execution>
+								<phase>generate-resources</phase>
 								<id>install node and npm</id>
 								<goals>
 									<goal>install-node-and-npm</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
 					<execution>
 						<phase>deploy</phase>
 						<configuration>
-							<target combine.children="append">
+							<target >
 								<mkdir dir="${project.basedir}/javascript/build" />
 								<copy todir="${project.build.directory}/classes/public">
 									<fileset dir="${project.basedir}/javascript/build" />


### PR DESCRIPTION
In this PR, we fix the order of the pom.xml steps so that the React App build happens before the app is copied into the directory from which it is served.