### PR TITLE
5pm-3: Fixed logo url path to make logo stop disappearing 

### DIFF
--- a/javascript/src/main/components/Nav/AppNavbar.js
+++ b/javascript/src/main/components/Nav/AppNavbar.js
@@ -24,7 +24,7 @@ function AppNavbar() {
       <Navbar.Collapse>
       <LinkContainer to={""}>
         <Navbar.Brand data-testid="brand">
-          <p className="brand"><img className="brand" src={'proj-ucsb-courses-search-240x240.png'}  alt="UCSB Courses Search icon"  /></p>
+          <p className="brand"><img className="brand" src={'/proj-ucsb-courses-search-240x240.png'}  alt="UCSB Courses Search icon"  /></p>
           <p className="brand">UCSB <br />Courses Search</p>
           </Navbar.Brand>
       </LinkContainer>


### PR DESCRIPTION
dw cb - This pull request fixes an error in the courses search logo path: changing it from a relative path to an absolute path. 
Logo will no longer disappear when switching between pages.