### PR TITLE
wl, ba 5pm-3 - changed size of header to match the others

### DIFF
--- a/javascript/src/main/pages/History/Basic.js
+++ b/javascript/src/main/pages/History/Basic.js
@@ -20,7 +20,7 @@ const Basic = () => {
     return (
         <Jumbotron>
             <div className="text-left">
-                <h5>Search Archived Course Data</h5>
+                <h2>Search Archived Course Data</h2>
                 <p>Data on this page is accurate for past quarters, but may be 
                     incomplete or out of date for current and future quarters.
                     Course information is not immediately updated.</p>


### PR DESCRIPTION
In this PR, we changed the size of header on basic search from h5 to h2 to match other searches. 