### PR TITLE
5pm-3 TP Added code so that the Home page and Basic Search page now shows Fall 2008 to Spring 2021 instead of a hard coded list of 3 quarters

### DIFF
--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -9,9 +9,9 @@ import { quarterRange } from "main/utils/quarterUtilities";
 import SelectQuarter from "main/components/BasicCourseSearch/SelectQuarter";
 
 const BasicCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
-	const quarters = quarterRange("20081", "20211");
+	const quarters = quarterRange("20084", "20214");
 	const firstDepartment = allTheSubjects[0].subjectCode;
-	const [quarter, setQuarter] = useState("20212");
+	const [quarter, setQuarter] = useState(quarters[0].yyyyq);
 	const [subject, setSubject] = useState(firstDepartment);
 	const [level, setLevel] = useState("U");
 	const { addToast } = useToasts();
@@ -45,10 +45,6 @@ const BasicCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
 		});
 	};
 
-	const handleQuarterOnChange = (event) => {
-		setQuarter(event.target.value);
-	};
-
 	const handleLevelOnChange = (event) => {
 		setLevel(event.target.value);
 	};
@@ -58,7 +54,7 @@ const BasicCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
 			<SelectQuarter
 				quarters={quarters}
 				quarter={quarter}
-				setQuarter={handleQuarterOnChange}
+				setQuarter={setQuarter}
 				controlId={"BasicSearch.Quarter"}
 				label={"Quarter"}
 			/>

--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -5,77 +5,82 @@ import useSWR from "swr";
 import { useToasts } from "react-toast-notifications";
 import { allTheSubjects } from "main/fixtures/Courses/subjectFixtures";
 import { fetchSubjectAreas } from "main/services/subjectAreaService";
+import { quarterRange } from "main/utils/quarterUtilities";
+import SelectQuarter from "main/components/BasicCourseSearch/SelectQuarter";
 
 const BasicCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
-    const firstDepartment = allTheSubjects[0].subjectCode;
-    const [quarter, setQuarter] = useState("20212");
-    const [subject, setSubject] = useState(firstDepartment);
-    const [level, setLevel] = useState("U");
-    const { addToast } = useToasts();
-    const [errorNotified, setErrorNotified] = useState(false);
+	const quarters = quarterRange("20081", "20211");
+	const firstDepartment = allTheSubjects[0].subjectCode;
+	const [quarter, setQuarter] = useState("20212");
+	const [subject, setSubject] = useState(firstDepartment);
+	const [level, setLevel] = useState("U");
+	const { addToast } = useToasts();
+	const [errorNotified, setErrorNotified] = useState(false);
 
-    const { data: subjects, error: errorGettingSubjects } = useSWR(
-        "/api/public/subjects",
-        fetchSubjectAreas,
-        {
-            initialData: allTheSubjects,
-            revalidateOnMount: true
-        }
-    );
+	const { data: subjects, error: errorGettingSubjects } = useSWR(
+		"/api/public/subjects",
+		fetchSubjectAreas,
+		{
+			initialData: allTheSubjects,
+			revalidateOnMount: true,
+		}
+	);
 
-    useEffect(
-        () => {
-            if (!errorNotified && errorGettingSubjects) {
-              addToast(`${errorGettingSubjects}`, { appearance: "error" });
-              setErrorNotified(true);
-            }
-        },
-        [errorGettingSubjects, errorNotified, addToast]
-    );
+	useEffect(() => {
+		if (!errorNotified && errorGettingSubjects) {
+			addToast(`${errorGettingSubjects}`, { appearance: "error" });
+			setErrorNotified(true);
+		}
+	}, [errorGettingSubjects, errorNotified, addToast]);
 
-    const handleSubmit = (event) => {
-        event.preventDefault();
-        fetchJSON(event, { quarter, subject, level }).then((courseJSON) => {
-            if(courseJSON.total === 0){
-                addToast("There are no courses that match the requested criteria.", { appearance: "error" });
-            }
-            setCourseJSON(courseJSON);
-        });
-    };
+	const handleSubmit = (event) => {
+		event.preventDefault();
+		fetchJSON(event, { quarter, subject, level }).then((courseJSON) => {
+			if (courseJSON.total === 0) {
+				addToast("There are no courses that match the requested criteria.", {
+					appearance: "error",
+				});
+			}
+			setCourseJSON(courseJSON);
+		});
+	};
 
-    const handleQuarterOnChange = (event) => {
-        setQuarter(event.target.value);
-    };
+	const handleQuarterOnChange = (event) => {
+		setQuarter(event.target.value);
+	};
 
-    const handleLevelOnChange = (event) => {
-        setLevel(event.target.value);
-    };
+	const handleLevelOnChange = (event) => {
+		setLevel(event.target.value);
+	};
 
-    return (
-        <Form onSubmit={handleSubmit}>
-            <Form.Group controlId="BasicSearch.Quarter">
-                <Form.Label>Quarter</Form.Label>
-                <Form.Control as="select" onChange={handleQuarterOnChange} value={quarter} data-testid="select-quarter" >
-                    <option value="20212">S21</option>
-                    <option value="20211">W21</option>
-                    <option value="20204">F20</option>
-                </Form.Control>
-            </Form.Group>
-            <SelectSubject subjects={subjects} subject={subject} setSubject={setSubject} />
-            <Form.Group controlId="BasicSearch.CourseLevel">
-                <Form.Label>Course Level</Form.Label>
-                <Form.Control as="select" onChange={handleLevelOnChange} value={level}>
-                    <option value="L">Undergrad-Lower Division</option>
-                    <option value="S">Undergrad-Upper Division</option>
-                    <option value="U">Undergrad-All</option>
-                    <option value="G">Graduate</option>
-                </Form.Control>
-            </Form.Group>
-            <Button variant="primary" type="submit">
-                Submit
-            </Button>
-        </Form>
-    );
+	return (
+		<Form onSubmit={handleSubmit}>
+			<SelectQuarter
+				quarters={quarters}
+				quarter={quarter}
+				setQuarter={handleQuarterOnChange}
+				controlId={"BasicSearch.Quarter"}
+				label={"Quarter"}
+			/>
+			<SelectSubject
+				subjects={subjects}
+				subject={subject}
+				setSubject={setSubject}
+			/>
+			<Form.Group controlId="BasicSearch.CourseLevel">
+				<Form.Label>Course Level</Form.Label>
+				<Form.Control as="select" onChange={handleLevelOnChange} value={level}>
+					<option value="L">Undergrad-Lower Division</option>
+					<option value="S">Undergrad-Upper Division</option>
+					<option value="U">Undergrad-All</option>
+					<option value="G">Graduate</option>
+				</Form.Control>
+			</Form.Group>
+			<Button variant="primary" type="submit">
+				Submit
+			</Button>
+		</Form>
+	);
 };
 
 export default BasicCourseSearchForm;

--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -9,7 +9,7 @@ import { quarterRange } from "main/utils/quarterUtilities";
 import SelectQuarter from "main/components/BasicCourseSearch/SelectQuarter";
 
 const BasicCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
-	const quarters = quarterRange("20084", "20214");
+	const quarters = quarterRange("20084", "20213");
 	const firstDepartment = allTheSubjects[0].subjectCode;
 	const [quarter, setQuarter] = useState(quarters[0].yyyyq);
 	const [subject, setSubject] = useState(firstDepartment);

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
@@ -1,52 +1,60 @@
 import React, { useState } from "react";
-import { Form, Button} from "react-bootstrap";
+import { Form, Button } from "react-bootstrap";
 import { useToasts } from "react-toast-notifications";
+import { quarterRange } from "main/utils/quarterUtilities";
+import SelectQuarter from "main/components/BasicCourseSearch/SelectQuarter";
 
 const CourseSearchFormQtrDeptOnly = ({ setCourseJSON, fetchJSON }) => {
-    const [quarter, setQuarter] = useState("20212");
-    const [department, setDepartment] = useState("CMPSC");
-    const { addToast } = useToasts()
-    
-    const handleSubmit = (event) => {
-        event.preventDefault();
-        fetchJSON(event, { quarter, department }).then((courseJSON) => {
-            if(courseJSON.total === 0){
-                addToast("There are no courses that match the requested criteria.", { appearance: "error" });
-            }
-            setCourseJSON(courseJSON);
-        });
-    };
+	const quarters = quarterRange("20081", "20211");
+	const [quarter, setQuarter] = useState("20212");
+	const [department, setDepartment] = useState("CMPSC");
+	const { addToast } = useToasts();
 
-    const handleQuarterOnChange = (event) => {
-        setQuarter(event.target.value);
-    };
+	const handleSubmit = (event) => {
+		event.preventDefault();
+		fetchJSON(event, { quarter, department }).then((courseJSON) => {
+			if (courseJSON.total === 0) {
+				addToast("There are no courses that match the requested criteria.", {
+					appearance: "error",
+				});
+			}
+			setCourseJSON(courseJSON);
+		});
+	};
 
-    const handleDepartmentOnChange = (event) => {
-        setDepartment(event.target.value);
-    };
+	const handleQuarterOnChange = (event) => {
+		setQuarter(event.target.value);
+	};
 
-    return (
-        <Form onSubmit={handleSubmit}>
-            <Form.Group controlId="BasicSearch.Quarter">
-                <Form.Label>Quarter</Form.Label>
-                <Form.Control as="select" onChange={handleQuarterOnChange} value={quarter}  >
-                    <option value="20212">S21</option>
-                    <option value="20211">W21</option>
-                    <option value="20204">F20</option>
-                </Form.Control>
-            </Form.Group>
-            <Form.Group controlId="BasicSearch.Department">
-                <Form.Label>Department</Form.Label>
-                <Form.Control as="select" onChange={handleDepartmentOnChange} value={department}>
-                    <option>CMPSC</option>
-                    <option>MATH</option>
-                </Form.Control>
-            </Form.Group>
-            <Button variant="primary" type="submit">
-                Submit
-            </Button>
-        </Form>
-    );
+	const handleDepartmentOnChange = (event) => {
+		setDepartment(event.target.value);
+	};
+
+	return (
+		<Form onSubmit={handleSubmit}>
+			<SelectQuarter
+				quarters={quarters}
+				quarter={quarter}
+				setQuarter={handleQuarterOnChange}
+				controlId={"BasicSearch.Quarter"}
+				label={"Quarter"}
+			/>
+			<Form.Group controlId="BasicSearch.Department">
+				<Form.Label>Department</Form.Label>
+				<Form.Control
+					as="select"
+					onChange={handleDepartmentOnChange}
+					value={department}
+				>
+					<option>CMPSC</option>
+					<option>MATH</option>
+				</Form.Control>
+			</Form.Group>
+			<Button variant="primary" type="submit">
+				Submit
+			</Button>
+		</Form>
+	);
 };
 
 export default CourseSearchFormQtrDeptOnly;

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
@@ -5,7 +5,7 @@ import { quarterRange } from "main/utils/quarterUtilities";
 import SelectQuarter from "main/components/BasicCourseSearch/SelectQuarter";
 
 const CourseSearchFormQtrDeptOnly = ({ setCourseJSON, fetchJSON }) => {
-	const quarters = quarterRange("20084", "20214");
+	const quarters = quarterRange("20084", "20213");
 	const [quarter, setQuarter] = useState(quarters[0].yyyyq);
 	const [department, setDepartment] = useState("CMPSC");
 	const { addToast } = useToasts();

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
@@ -5,8 +5,8 @@ import { quarterRange } from "main/utils/quarterUtilities";
 import SelectQuarter from "main/components/BasicCourseSearch/SelectQuarter";
 
 const CourseSearchFormQtrDeptOnly = ({ setCourseJSON, fetchJSON }) => {
-	const quarters = quarterRange("20081", "20211");
-	const [quarter, setQuarter] = useState("20212");
+	const quarters = quarterRange("20084", "20214");
+	const [quarter, setQuarter] = useState(quarters[0].yyyyq);
 	const [department, setDepartment] = useState("CMPSC");
 	const { addToast } = useToasts();
 
@@ -22,10 +22,6 @@ const CourseSearchFormQtrDeptOnly = ({ setCourseJSON, fetchJSON }) => {
 		});
 	};
 
-	const handleQuarterOnChange = (event) => {
-		setQuarter(event.target.value);
-	};
-
 	const handleDepartmentOnChange = (event) => {
 		setDepartment(event.target.value);
 	};
@@ -35,7 +31,7 @@ const CourseSearchFormQtrDeptOnly = ({ setCourseJSON, fetchJSON }) => {
 			<SelectQuarter
 				quarters={quarters}
 				quarter={quarter}
-				setQuarter={handleQuarterOnChange}
+				setQuarter={setQuarter}
 				controlId={"BasicSearch.Quarter"}
 				label={"Quarter"}
 			/>

--- a/javascript/src/test/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/javascript/src/test/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -1,201 +1,207 @@
 import React from "react";
 import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useToasts } from 'react-toast-notifications'
+import { useToasts } from "react-toast-notifications";
 import useSWR from "swr";
 import { allTheSubjects } from "main/fixtures/Courses/subjectFixtures";
-
 
 import BasicCourseSearchForm from "main/components/BasicCourseSearch/BasicCourseSearchForm";
 jest.mock("swr");
 
 jest.mock("react-toast-notifications", () => ({
-    useToasts: jest.fn()
+	useToasts: jest.fn(),
 }));
 
 describe("BasicCourseSearchForm tests", () => {
+	const addToast = jest.fn();
+	beforeEach(() => {
+		useSWR.mockReturnValue({
+			data: allTheSubjects,
+			error: undefined,
+		});
+		useToasts.mockReturnValue({
+			addToast: addToast,
+		});
+	});
 
-    const addToast = jest.fn();
-    beforeEach(() => {
-        useSWR.mockReturnValue({
-            data: allTheSubjects,
-            error: undefined
-          });
-        useToasts.mockReturnValue({
-            addToast: addToast
-          })
-    });
+	test("renders without crashing", () => {
+		render(<BasicCourseSearchForm />);
+	});
 
-    test("renders without crashing", () => {
-        render(<BasicCourseSearchForm />);
-    });
+	test("when I select a quarter, the state for quarter changes", () => {
+		const { getByLabelText } = render(<BasicCourseSearchForm />);
+		const selectQuarter = getByLabelText("Quarter");
+		userEvent.selectOptions(selectQuarter, "20204");
+		expect(selectQuarter.value).toBe("20204");
+	});
 
-    test("when I select a quarter, the state for quarter changes", () => {
-        const { getByTestId } = render(<BasicCourseSearchForm />);
-        const selectQuarter = getByTestId("select-quarter")
-        userEvent.selectOptions(selectQuarter, "20204");
-        expect(selectQuarter.value).toBe("20204");
-    });
+	test("when I select a subject, the state for subject changes", () => {
+		const { getByLabelText } = render(<BasicCourseSearchForm />);
+		const selectSubject = getByLabelText("Subject Area");
+		userEvent.selectOptions(selectSubject, "MATH");
+		expect(selectSubject.value).toBe("MATH");
+	});
 
-    test("when I select a subject, the state for subject changes", () => {
-        const { getByLabelText } = render(<BasicCourseSearchForm />);
-        const selectSubject = getByLabelText("Subject Area")
-        userEvent.selectOptions(selectSubject, "MATH");
-        expect(selectSubject.value).toBe("MATH");
-    });
+	test("when I select a level, the state for level changes", () => {
+		const { getByLabelText } = render(<BasicCourseSearchForm />);
+		const selectLevel = getByLabelText("Course Level");
+		userEvent.selectOptions(selectLevel, "G");
+		expect(selectLevel.value).toBe("G");
+	});
 
-    test("when I select a level, the state for level changes", () => {
-        const { getByLabelText } = render(<BasicCourseSearchForm />);
-        const selectLevel = getByLabelText("Course Level")
-        userEvent.selectOptions(selectLevel, "G");
-        expect(selectLevel.value).toBe("G");
-    });
+	test("when I click submit, the right stuff happens", async () => {
+		const sampleReturnValue = {
+			sampleKey: "sampleValue",
+		};
 
-    test("when I click submit, the right stuff happens", async () => {
+		// Create spy functions (aka jest function, magic function)
+		// The function doesn't have any implementation unless
+		// we specify one.  But it does keep track of whether
+		// it was called, how many times it was called,
+		// and what it was passed.
 
-        const sampleReturnValue = {
-            "sampleKey": "sampleValue"
-        };
+		const setCourseJSONSpy = jest.fn();
+		const fetchJSONSpy = jest.fn();
 
-        // Create spy functions (aka jest function, magic function)
-        // The function doesn't have any implementation unless
-        // we specify one.  But it does keep track of whether 
-        // it was called, how many times it was called,
-        // and what it was passed.
+		fetchJSONSpy.mockResolvedValue(sampleReturnValue);
 
-        const setCourseJSONSpy = jest.fn();
-        const fetchJSONSpy = jest.fn();
+		const { getByText, getByLabelText } = render(
+			<BasicCourseSearchForm
+				setCourseJSON={setCourseJSONSpy}
+				fetchJSON={fetchJSONSpy}
+			/>
+		);
 
-        fetchJSONSpy.mockResolvedValue(sampleReturnValue);
+		const expectedFields = {
+			quarter: "20204",
+			subject: "MATH",
+			level: "G",
+		};
 
-        const { getByText, getByLabelText } = render(
-            <BasicCourseSearchForm setCourseJSON={setCourseJSONSpy} fetchJSON={fetchJSONSpy} />
-        );
+		const selectQuarter = getByLabelText("Quarter");
+		userEvent.selectOptions(selectQuarter, "20204");
+		const selectSubject = getByLabelText("Subject Area");
+		userEvent.selectOptions(selectSubject, "MATH");
+		const selectLevel = getByLabelText("Course Level");
+		userEvent.selectOptions(selectLevel, "G");
 
-        const expectedFields = {
-            quarter: "20204",
-            subject: "MATH",
-            level: "G"
-        };
+		const submitButton = getByText("Submit");
+		userEvent.click(submitButton);
 
-        const selectQuarter = getByLabelText("Quarter")
-        userEvent.selectOptions(selectQuarter, "20204");
-        const selectSubject = getByLabelText("Subject Area")
-        userEvent.selectOptions(selectSubject, "MATH");
-        const selectLevel = getByLabelText("Course Level")
-        userEvent.selectOptions(selectLevel, "G");
+		// we need to be careful not to assert this expectation
+		// until all of the async promises are resolved
+		await waitFor(() => expect(setCourseJSONSpy).toHaveBeenCalledTimes(1));
+		await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
 
-        const submitButton = getByText("Submit");
-        userEvent.click(submitButton);
+		// assert that ourSpy was called with the right value
+		expect(setCourseJSONSpy).toHaveBeenCalledWith(sampleReturnValue);
+		expect(fetchJSONSpy).toHaveBeenCalledWith(
+			expect.any(Object),
+			expectedFields
+		);
+	});
 
-        // we need to be careful not to assert this expectation
-        // until all of the async promises are resolved
-        await waitFor(() => expect(setCourseJSONSpy).toHaveBeenCalledTimes(1));
-        await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
+	test("when I click submit when JSON is EMPTY, setCourse is not called!", async () => {
+		const sampleReturnValue = {
+			sampleKey: "sampleValue",
+			total: 0,
+		};
 
-        // assert that ourSpy was called with the right value
-        expect(setCourseJSONSpy).toHaveBeenCalledWith(sampleReturnValue);
-        expect(fetchJSONSpy).toHaveBeenCalledWith(expect.any(Object), expectedFields);
+		// Create spy functions (aka jest function, magic function)
+		// The function doesn't have any implementation unless
+		// we specify one.  But it does keep track of whether
+		// it was called, how many times it was called,
+		// and what it was passed.
 
-    });
+		const setCourseJSONSpy = jest.fn();
+		const fetchJSONSpy = jest.fn();
 
-    test("when I click submit when JSON is EMPTY, setCourse is not called!", async () => {
+		fetchJSONSpy.mockResolvedValue(sampleReturnValue);
 
-        const sampleReturnValue = {
-            "sampleKey": "sampleValue",
-            "total": 0
-        };
+		const { getByText, getByLabelText } = render(
+			<BasicCourseSearchForm
+				setCourseJSON={setCourseJSONSpy}
+				fetchJSON={fetchJSONSpy}
+			/>
+		);
 
-        // Create spy functions (aka jest function, magic function)
-        // The function doesn't have any implementation unless
-        // we specify one.  But it does keep track of whether 
-        // it was called, how many times it was called,
-        // and what it was passed.
+		const selectQuarter = getByLabelText("Quarter");
+		userEvent.selectOptions(selectQuarter, "20204");
+		const selectSubject = getByLabelText("Subject Area");
+		userEvent.selectOptions(selectSubject, "MATH");
+		const selectLevel = getByLabelText("Course Level");
+		userEvent.selectOptions(selectLevel, "G");
 
-        const setCourseJSONSpy = jest.fn();
-        const fetchJSONSpy = jest.fn();
+		const submitButton = getByText("Submit");
+		userEvent.click(submitButton);
 
-        fetchJSONSpy.mockResolvedValue(sampleReturnValue);
+		// we need to be careful not to assert this expectation
+		// until all of the async promises are resolved
+		await waitFor(() => expect(setCourseJSONSpy).toHaveBeenCalledTimes(0));
+	});
 
-        const { getByText, getByLabelText } = render(
-            <BasicCourseSearchForm setCourseJSON={setCourseJSONSpy} fetchJSON={fetchJSONSpy} />
-        );
+	test("the download csv button seems to work", async () => {
+		const sampleReturnValue = {
+			sampleKey: "sampleValue",
+		};
 
-        const selectQuarter = getByLabelText("Quarter")
-        userEvent.selectOptions(selectQuarter, "20204");
-        const selectSubject = getByLabelText("Subject Area")
-        userEvent.selectOptions(selectSubject, "MATH");
-        const selectLevel = getByLabelText("Course Level")
-        userEvent.selectOptions(selectLevel, "G");
+		// Create spy functions (aka jest function, magic function)
+		// The function doesn't have any implementation unless
+		// we specify one.  But it does keep track of whether
+		// it was called, how many times it was called,
+		// and what it was passed.
 
-        const submitButton = getByText("Submit");
-        userEvent.click(submitButton);
+		const setCourseJSONSpy = jest.fn();
+		const fetchJSONSpy = jest.fn();
 
-        // we need to be careful not to assert this expectation
-        // until all of the async promises are resolved
-        await waitFor(() => expect(setCourseJSONSpy).toHaveBeenCalledTimes(0));
+		fetchJSONSpy.mockResolvedValue(sampleReturnValue);
 
-    });
+		const { getByText, getByLabelText } = render(
+			<BasicCourseSearchForm
+				setCourseJSON={setCourseJSONSpy}
+				fetchJSON={fetchJSONSpy}
+			/>
+		);
 
-    test("the download csv button seems to work", async () => {
+		const expectedFields = {
+			quarter: "20204",
+			subject: "MATH",
+			level: "G",
+		};
 
-        const sampleReturnValue = {
-            "sampleKey": "sampleValue"
-        };
+		const selectQuarter = getByLabelText("Quarter");
+		userEvent.selectOptions(selectQuarter, "20204");
+		const selectSubject = getByLabelText("Subject Area");
+		userEvent.selectOptions(selectSubject, "MATH");
+		const selectLevel = getByLabelText("Course Level");
+		userEvent.selectOptions(selectLevel, "G");
 
-        // Create spy functions (aka jest function, magic function)
-        // The function doesn't have any implementation unless
-        // we specify one.  But it does keep track of whether 
-        // it was called, how many times it was called,
-        // and what it was passed.
+		const submitButton = getByText("Submit");
+		userEvent.click(submitButton);
 
-        const setCourseJSONSpy = jest.fn();
-        const fetchJSONSpy = jest.fn();
+		// we need to be careful not to assert this expectation
+		// until all of the async promises are resolved
+		await waitFor(() => expect(setCourseJSONSpy).toHaveBeenCalledTimes(1));
+		await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
 
-        fetchJSONSpy.mockResolvedValue(sampleReturnValue);
+		// assert that ourSpy was called with the right value
+		expect(setCourseJSONSpy).toHaveBeenCalledWith(sampleReturnValue);
+		expect(fetchJSONSpy).toHaveBeenCalledWith(
+			expect.any(Object),
+			expectedFields
+		);
 
-        const { getByText, getByLabelText } = render(
-            <BasicCourseSearchForm setCourseJSON={setCourseJSONSpy} fetchJSON={fetchJSONSpy} />
-        );
+		// lets try the download csv now
+		// const csvButton = getByText("Download CSV");
+		// userEvent.click(csvButton);
+	});
 
-        const expectedFields = {
-            quarter: "20204",
-            subject: "MATH",
-            level: "G"
-        };
-
-        const selectQuarter = getByLabelText("Quarter")
-        userEvent.selectOptions(selectQuarter, "20204");
-        const selectSubject = getByLabelText("Subject Area")
-        userEvent.selectOptions(selectSubject, "MATH");
-        const selectLevel = getByLabelText("Course Level")
-        userEvent.selectOptions(selectLevel, "G");
-
-        const submitButton = getByText("Submit");
-        userEvent.click(submitButton);
-
-        // we need to be careful not to assert this expectation
-        // until all of the async promises are resolved
-        await waitFor(() => expect(setCourseJSONSpy).toHaveBeenCalledTimes(1));
-        await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
-
-        // assert that ourSpy was called with the right value
-        expect(setCourseJSONSpy).toHaveBeenCalledWith(sampleReturnValue);
-        expect(fetchJSONSpy).toHaveBeenCalledWith(expect.any(Object), expectedFields);
-
-        // lets try the download csv now
-        // const csvButton = getByText("Download CSV");
-        // userEvent.click(csvButton);
-    });
-
-    test("if the backend endpoint for subjects is down, we get a toast", async () => {
-        useSWR.mockReturnValue({
-            data: allTheSubjects,
-            error: new Error("mock Error")
-          });
-        render(<BasicCourseSearchForm />);
-        expect(addToast).toHaveBeenCalled();
-    });
-
+	test("if the backend endpoint for subjects is down, we get a toast", async () => {
+		useSWR.mockReturnValue({
+			data: allTheSubjects,
+			error: new Error("mock Error"),
+		});
+		render(<BasicCourseSearchForm />);
+		expect(addToast).toHaveBeenCalled();
+	});
 });
-


### PR DESCRIPTION
## User Story
As a user, I can now select Quarters from Fall 2008 to Fall 2021 on the Home page and Basic Search page. Now, the user can see a larger list of history of courses.

## Main Changes
Added quarterRange function and SelectQuarter component to create a new form that shows an expandable list of quarters in the given range.
The list of quarters is generated by the quarterRange function with startQuarter and endQuarter input
The QuarterSelector form is generated by SelectQuarter component given {quarters, quarter, setQuarter, controlId, label} props.
Changed the select quarter test case in BasicCourseSearchForm tests to use getByLabelText instead of getByTestID since the SelectQuarter component does not use data-testid prop

## Files Changed
javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
javascript/src/test/components/BasicCourseSearch/BasicCourseSearchForm.test.js

P.S.
Sorry, Prettier formatted the entire file. Will look into ways to make it so that it only formats my changes or disable it all together for future projects