### PR TITLE
IG MH - fixed the issue where basic history search was not returning any results

### DIFF
--- a/javascript/src/main/services/courseSearches.js
+++ b/javascript/src/main/services/courseSearches.js
@@ -7,7 +7,7 @@ import fetch from "isomorphic-unfetch";
 };
 
 const fetchBasicCourseHistoryJSON = async (_event, fields) => {
-    const url = `/api/public/history/basicsearch?qtr=${fields.quarter}&dept=${fields.subject}`;
+    const url = `/api/public/history/basicsearch?qtr=${fields.quarter}&dept=${fields.department}`;
     const courseResponse = await fetch(url);
     return courseResponse.json();
 };


### PR DESCRIPTION
In this pull request, we fixed the url to fetch JSON from the correct endpoint for the /history/basic route. 