### PR TITLE
mm/sl 5pm-2 - Give sections italic font instead of regular

### DIFF
--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
@@ -15,7 +15,9 @@ const BasicCourseTable = ({ classes, checks, displayQuarter, allowExport }) => {
   const COLOR_UNAVAILABLE = availabilityColors.UNAVAILABLE;
   const COLOR_CLOSEFULL = availabilityColors.CLOSEFULL;
   const COLOR_AVAILABLELECTUREORCLASSWITHSECTIONS = {backgroundColor: '#CEDEFA'};
-  const COLOR_AVAILABLESECTION = {backgroundColor: '#EDF3FE'};
+  const COLOR_AVAILABLESECTION = {backgroundColor: '#EDF3FE', fontStyle: 'italic'};
+  const COLOR_UNAVAILABLESECTION = {backgroundColor: '#FF8080', fontStyle: 'italic' };
+  const COLOR_CLOSEFULLSECTION = {backgroundColor: '#FFD761', fontStyle: 'italic' };
   const CLOSEFULL_THRESHOLD=0.2;
   const classUnavailable = (row) => (row.enrolledTotal >= row.maxEnroll || row.courseCancelled === "Y" || row.classClosed ==="Y"); 
 
@@ -45,10 +47,10 @@ const BasicCourseTable = ({ classes, checks, displayQuarter, allowExport }) => {
     else {
       //This code should only execute when dealing with sections.
       if (classUnavailable(row)) {
-        return COLOR_UNAVAILABLE;
+        return COLOR_UNAVAILABLESECTION;
       }
       if (closeToFull(row)) {
-        return COLOR_CLOSEFULL;
+        return COLOR_CLOSEFULLSECTION;
       }
       return COLOR_AVAILABLESECTION;
     }


### PR DESCRIPTION
As a user I can see sections in italic so that I can easily distinguish sections from lecture at a glance.

NOTE:
After consulting with an LA, due to the way the code is already implemented, writing tests for this issue would require a large portion of the code to be rewritten to make it testable and is beyond the scope of this story. 