### PR TITLE
TP - Fixed Issue where selecting F21 quarter on the Home page is causing it to crash

### DIFF
--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -9,7 +9,7 @@ import { quarterRange } from "main/utils/quarterUtilities";
 import SelectQuarter from "main/components/BasicCourseSearch/SelectQuarter";
 
 const BasicCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
-	const quarters = quarterRange("20084", "20213");
+	const quarters = quarterRange("20084", "20214");
 	const firstDepartment = allTheSubjects[0].subjectCode;
 	const [quarter, setQuarter] = useState(quarters[0].yyyyq);
 	const [subject, setSubject] = useState(firstDepartment);

--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
@@ -27,7 +27,7 @@ const BasicCourseTable = ({ classes, checks, displayQuarter, allowExport }) => {
       //the color to we do something.
 
       for (var i in classes) {
-        if (classes[i].classSections[0].enrollCode === row.enrollCode && classes[i].classSections[0].section === row.section) {
+        if (classes[i].classSections.length > 0 && classes[i].classSections[0].enrollCode === row.enrollCode && classes[i].classSections[0].section === row.section) {
           if (classes[i].classSections.length === 1) {
             //This code should only execute when dealing with stand alone lectures.
             if (classUnavailable(row)) {


### PR DESCRIPTION
## User Story
As a user, I am now able to look up Fall 2021 classes normally, allowing the user to look further into the future and plan ahead.

## Development Changes
Added a guard statement stating that the length of class.classSections array must be larger than 0 so that we no longer index into empty classSections arrays (an edge case that was recently discovered) and cause the frontend to crash.

## Tests:
- [x] All Maven tests passed
- [ ] All npm test suites and tests passed
- [ ] Passed GitHub Actions tests
- [ ] Works on localhost
- [ ] Deployed to Heroku

## Files Changed:
javascript/main/components/BasicCourseSearchForm.js
javascript/main/components/BasicCourseSearchTable.js