### PR TITLE
5pm-2 kt - Make table of course search results invisible initially and if there are no search results

### DIFF
--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
@@ -183,7 +183,7 @@ const BasicCourseTable = ({ classes, checks, displayQuarter, allowExport }) => {
     }
   );
 
-  if (sections===[] || sections===null) {
+  if ((sections.length === 0) || (sections===null)) {
     return (
       <div data-testid="no-course-data">
       </div>

--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
@@ -182,6 +182,14 @@ const BasicCourseTable = ({ classes, checks, displayQuarter, allowExport }) => {
       text: 'YYYYQ'
     }
   );
+
+  if (sections===[] || sections===null) {
+    return (
+      <div data-testid="no-course-data">
+      </div>
+    )
+  }
+  
   return (
     <ToolkitProvider
       keyField="uniqueKey"

--- a/javascript/src/test/components/BasicCourseSearch/BasicCourseTable.test.js
+++ b/javascript/src/test/components/BasicCourseSearch/BasicCourseTable.test.js
@@ -13,11 +13,12 @@ describe("BasicCourseTable tests", () => {
     });
 
   })
-  test("renders without crashing", () => {
+  test("for empty list, we get an empty div with  data-testid='no-course-data' ", () => {
     useAuth0.mockReturnValue({
       isAuthenticated: true,
     });
-    render(<BasicCourseTable classes={[]}/>);
+    const {getByTestId} = render(<BasicCourseTable classes={[]}/>);
+    expect(getByTestId("no-course-data")).not.toBe(null);
   });
 
   function getBackgroundColor (getByText, text) {


### PR DESCRIPTION
- Tweaks BasicCourseTable.js to return an empty div element with id="no-course-data" if the search's resultant courses array is empty.
- Fixes #273 