### PR TITLE
IG MH - added enrolled and course capacity columns to display in the BasicCourseTable

### DIFF
--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
@@ -53,6 +53,14 @@ const BasicCourseTable = ({ classes, checks, displayQuarter, allowExport }) => {
       return COLOR_AVAILABLESECTION;
     }
   }
+  const renderCourseEnrolled = (_cell, row) => {
+    const enrolled = row.enrolledTotal;
+    return (enrolled)
+  }
+  const renderCourseCapacity = (_cell, row) => {
+    const capacity = row.maxEnroll;
+    return (capacity)
+  }
   const renderSectionTimes = (_cell, row) => {
     const times = (row.timeLocations.length > 0) ? (row.timeLocations[0].beginTime + " - " + row.timeLocations[0].endTime) : ("TBD");
     return times
@@ -131,6 +139,16 @@ const BasicCourseTable = ({ classes, checks, displayQuarter, allowExport }) => {
     text: 'Time',
     formatter: (cell, row) => renderSectionTimes(cell, row),
     csvFormatter: (cell, row) => renderSectionTimes(cell, row)
+  }, {
+    dataField: 'enrolledTotal',
+    text: 'Enrolled',
+    formatter: (cell, row) => renderCourseEnrolled(cell, row),
+    csvFormatter: (cell, row) => renderCourseEnrolled(cell, row)
+  }, {
+    dataField: 'maxEnroll',
+    text: 'Course Capacity',
+    formatter: (cell, row) => renderCourseCapacity(cell, row),
+    csvFormatter: (cell, row) => renderCourseCapacity(cell, row)
   }, {
     dataField: 'course.unitsFixed',
     text: 'Unit',

--- a/javascript/src/test/components/BasicCourseSearch/BasicCourseTable.test.js
+++ b/javascript/src/test/components/BasicCourseSearch/BasicCourseTable.test.js
@@ -115,6 +115,22 @@ describe("BasicCourseTable tests", () => {
     expect( queryAllByText("TBD").length).toBe(2);
   });
 
+  test("check that lectures enrollment appears", () => {
+    useAuth0.mockReturnValue({
+      isAuthenticated: true,
+    });
+    const {queryAllByText} = render(<BasicCourseTable classes = {courseFixtures.classesLectureOnly} />);
+    expect( queryAllByText("25").length).toBe(2);
+  });
+
+  test("check that lectures capacity appears", () => {
+    useAuth0.mockReturnValue({
+      isAuthenticated: true,
+    });
+    const {queryAllByText} = render(<BasicCourseTable classes = {courseFixtures.classesLectureOnly} />);
+    expect( queryAllByText("25").length).toBe(2);
+  });
+
   // Testing Sections
   test("check that sections course number does not appear", () => {
     useAuth0.mockReturnValue({
@@ -188,12 +204,28 @@ describe("BasicCourseTable tests", () => {
     expect( queryByText("09:00 - 09:50")).not.toBe(null);
   });
 
-  test("check that sections times and days appear as TBD when they don't exist", () => {
+ test("check that sections times and days appear as TBD when they don't exist", () => {
     useAuth0.mockReturnValue({
       isAuthenticated: true,
     });
     const {queryAllByText} = render(<BasicCourseTable classes = {courseFixtures.classesSectionOnlyTimeDaysTBD} />);
     expect( queryAllByText("TBD").length).toBe(5);
+  }); 
+
+  test("check that sections enrolled appears", () => {
+    useAuth0.mockReturnValue({
+      isAuthenticated: true,
+    });
+    const {queryAllByText} = render(<BasicCourseTable classes = {courseFixtures.classesSectionOnly} />);
+    expect( queryAllByText("25").length).toBe(2);
+  });
+
+  test("check that sections course capacity appears", () => {
+    useAuth0.mockReturnValue({
+      isAuthenticated: true,
+    });
+    const {queryAllByText} = render(<BasicCourseTable classes = {courseFixtures.classesSectionOnly} />);
+    expect( queryAllByText("25").length).toBe(2);
   });
 
   // Testing styling for classes w/more than one section


### PR DESCRIPTION
As a user I can see enrollment numbers on the basic course results form so that I can see how many students are enrolled, and what the max enrollment is.

Added "enrolled" and "course capacity" columns to the columns data structure in the component for basic course search results.
The pages that use the basic course form now show both capacity, and the number of students enrolled.

Also added test cases to test that the new columns were displaying the data correctly.