### PR TITLE
IG MH - Fixed bug where day/time columns were sometimes displaying null-null instead of TBD

### DIFF
--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
@@ -68,7 +68,7 @@ const BasicCourseTable = ({ classes, checks, displayQuarter, allowExport }) => {
 
     const times = ( (row.timeLocations.length > 0) && (row.timeLocations[0].days !== null) ) ? (row.timeLocations[0].beginTime + " - " + row.timeLocations[0].endTime) : ("TBD");
     
-    if(row.timeLocations[0].days == null){
+    if(times == "TBD"){
       return times
     }
 

--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
@@ -89,7 +89,6 @@ const BasicCourseTable = ({ classes, checks, displayQuarter, allowExport }) => {
       }
       return (resultStart + row.timeLocations[0].beginTime.substring(2) + timeTypeStart + " - " + resultEnd + row.timeLocations[0].endTime.substring(2) + timeTypeEnd)
     }
-    return ("TBD")
   }
   const renderSectionDays = (_cell, row) => {
 

--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
@@ -62,12 +62,12 @@ const BasicCourseTable = ({ classes, checks, displayQuarter, allowExport }) => {
     return (capacity)
   }
   const renderSectionTimes = (_cell, row) => {
-    const times = (row.timeLocations.length > 0) ? (row.timeLocations[0].beginTime + " - " + row.timeLocations[0].endTime) : ("TBD");
+    const times = ( (row.timeLocations.length > 0) && (row.timeLocations[0].days !== null) ) ? (row.timeLocations[0].beginTime + " - " + row.timeLocations[0].endTime) : ("TBD");
     return times
   }
   const renderSectionDays = (_cell, row) => {
 
-    const days = (row.timeLocations.length > 0) ? (row.timeLocations[0].days) : ("TBD");
+    const days = ( (row.timeLocations.length > 0) && (row.timeLocations[0].days !== null) ) ? (row.timeLocations[0].days) : ("TBD");
     return days
   }
   const renderCourseId = (_cell, row) => {

--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
@@ -68,7 +68,7 @@ const BasicCourseTable = ({ classes, checks, displayQuarter, allowExport }) => {
 
     const times = ( (row.timeLocations.length > 0) && (row.timeLocations[0].days !== null) ) ? (row.timeLocations[0].beginTime + " - " + row.timeLocations[0].endTime) : ("TBD");
     
-    if(times == "TBD"){
+    if(times === "TBD"){
       return times
     }
 


### PR DESCRIPTION
Basic course search results now follow the expected behavior:

Either a day/time should be displayed, or "TBD" should be displayed.

Previously, "null-null" would be shown instead of TBD for certain courses.

In the middle of making this PR, another feature was merged to main, which displayed times in an AM-PM format rather than a 24H format, which created a merge-conflict. The merged feature contained a bug that made certain searches crash and show a blank white page.

Our PR was updated to fix the bug caused by the previous feature, as well as still fixing the initial bug described above.