### PR TITLE
ey - 5pm 1 convert quarter text box to dropdown in personal schedule

### DIFF
--- a/javascript/src/main/components/Schedule/AddSchedForm.js
+++ b/javascript/src/main/components/Schedule/AddSchedForm.js
@@ -80,7 +80,7 @@ const AddSchedForm = ({ createSchedule, updateSchedule, existingSchedule }) => {
         quarter={quarter}
         setQuarter={handleQuarterOnChange}
         controlId={'PersonalSchedule.Quarter'}
-        label={'PersonalScheduleQuarter'}
+        label={'PQuarter'}
       />
 
       <Button variant="primary" type="submit" data-testid="schedule-submit">

--- a/javascript/src/main/components/Schedule/AddSchedForm.js
+++ b/javascript/src/main/components/Schedule/AddSchedForm.js
@@ -80,7 +80,7 @@ const AddSchedForm = ({ createSchedule, updateSchedule, existingSchedule }) => {
         quarter={quarter}
         setQuarter={handleQuarterOnChange}
         controlId={'PersonalSchedule.Quarter'}
-        label={'PQuarter'}
+        label={'Quarter'}
       />
 
       <Button variant="primary" type="submit" data-testid="schedule-submit">

--- a/javascript/src/main/components/Schedule/AddSchedForm.js
+++ b/javascript/src/main/components/Schedule/AddSchedForm.js
@@ -15,7 +15,9 @@ const AddSchedForm = ({ createSchedule, updateSchedule, existingSchedule }) => {
   const quarters = quarterRange('20084', '20214');
   const localQuarter = localStorage.getItem('PersonalSchedule.Quarter');
   const [quarter, setQuarter] = useState(
-    existingSchedule.quarter || localQuarter || quarters[0].yyyyq
+    (existingSchedule ? existingSchedule.quarter : null) ||
+      localQuarter ||
+      quarters[0].yyyyq
   );
 
   const handleSubmit = (event) => {
@@ -77,8 +79,8 @@ const AddSchedForm = ({ createSchedule, updateSchedule, existingSchedule }) => {
         quarters={quarters}
         quarter={quarter}
         setQuarter={handleQuarterOnChange}
-        controlId={'BasicSearch.Quarter'}
-        label={'Quarter'}
+        controlId={'PersonalSchedule.Quarter'}
+        label={'PersonalScheduleQuarter'}
       />
 
       <Button variant="primary" type="submit" data-testid="schedule-submit">

--- a/javascript/src/main/components/Schedule/AddSchedForm.js
+++ b/javascript/src/main/components/Schedule/AddSchedForm.js
@@ -1,70 +1,91 @@
-import React, { useState } from "react";
-import { Form, Button } from "react-bootstrap";
+import React, { useState } from 'react';
+import { Form, Button } from 'react-bootstrap';
+import SelectQuarter from 'main/components/BasicCourseSearch/SelectQuarter';
+import { quarterRange } from 'main/utils/quarterUtilities';
 
 const AddSchedForm = ({ createSchedule, updateSchedule, existingSchedule }) => {
+  const emptySchedule = {
+    name: '',
+    description: '',
+    quarter: '',
+    userId: '',
+  };
 
-    const emptySchedule = {
-        name: "",
-        description:"",
-        quarter:"",
-        userId:""
-    };
+  const [schedule, setSchedule] = useState(existingSchedule || emptySchedule);
+  const quarters = quarterRange('20084', '20214');
+  const localQuarter = localStorage.getItem('PersonalSchedule.Quarter');
+  const [quarter, setQuarter] = useState(
+    existingSchedule.quarter || localQuarter || quarters[0].yyyyq
+  );
 
-    const [schedule, setSchedule] = useState(existingSchedule || emptySchedule);
-
-    const handleSubmit = (event) => {
-        event.preventDefault();
-        if (createSchedule) {
-            createSchedule(schedule);
-        }
-        else{
-            updateSchedule(schedule, schedule.id);
-        }
-    };
-
-    const handleNameOnChange = (event) => {
-        setSchedule({
-            ...schedule,
-            name: event.target.value
-          });
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    if (createSchedule) {
+      createSchedule(schedule);
+    } else {
+      updateSchedule(schedule, schedule.id);
     }
+  };
 
-    const handleDescriptionOnChange = (event) => {
-        setSchedule({
-            ...schedule,
-            description: event.target.value
-          });
-    }
+  const handleNameOnChange = (event) => {
+    setSchedule({
+      ...schedule,
+      name: event.target.value,
+    });
+  };
 
-    const handleQuarterOnChange = (event) => {
-        setSchedule({
-          ...schedule,
-          quarter: event.target.value
-        });
-    }
+  const handleDescriptionOnChange = (event) => {
+    setSchedule({
+      ...schedule,
+      description: event.target.value,
+    });
+  };
 
-    return (
-        <Form onSubmit={handleSubmit}>
-            <Form.Group controlId="formsSchedName">
-                <Form.Label>Schedule Name</Form.Label>
-                <Form.Control type="text" placeholder="Enter Schedule Name" value={schedule.name} onChange={handleNameOnChange} data-testid="schedule-name" />
-            </Form.Group>
+  const handleQuarterOnChange = (quarter) => {
+    localStorage.setItem('PersonalSchedule.Quarter', quarter);
+    setQuarter(quarter);
+    setSchedule({
+      ...schedule,
+      quarter: quarter,
+    });
+  };
 
-            <Form.Group controlId="formSchedDes">
-                <Form.Label>Description</Form.Label>
-                <Form.Control type="text" placeholder="Enter Schedule Description" value={schedule.description} onChange={handleDescriptionOnChange} data-testid="schedule-description" />
-            </Form.Group>
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Form.Group controlId="formsSchedName">
+        <Form.Label>Schedule Name</Form.Label>
+        <Form.Control
+          type="text"
+          placeholder="Enter Schedule Name"
+          value={schedule.name}
+          onChange={handleNameOnChange}
+          data-testid="schedule-name"
+        />
+      </Form.Group>
 
-            <Form.Group controlId="formQuarter">
-                <Form.Label>Quarter</Form.Label>
-                <Form.Control type="text" placeholder="Enter Schedule Quarter" value={schedule.quarter} onChange={handleQuarterOnChange} data-testid="schedule-quarter" />
-            </Form.Group>
+      <Form.Group controlId="formSchedDes">
+        <Form.Label>Description</Form.Label>
+        <Form.Control
+          type="text"
+          placeholder="Enter Schedule Description"
+          value={schedule.description}
+          onChange={handleDescriptionOnChange}
+          data-testid="schedule-description"
+        />
+      </Form.Group>
+      <SelectQuarter
+        quarters={quarters}
+        quarter={quarter}
+        setQuarter={handleQuarterOnChange}
+        controlId={'BasicSearch.Quarter'}
+        label={'Quarter'}
+      />
 
-            <Button variant="primary" type="submit" data-testid="schedule-submit">
-                Submit
-            </Button>
-        </Form>
-    );
+      <Button variant="primary" type="submit" data-testid="schedule-submit">
+        Submit
+      </Button>
+    </Form>
+  );
 };
 
 export default AddSchedForm;

--- a/javascript/src/main/components/Schedule/ScheduleTable.js
+++ b/javascript/src/main/components/Schedule/ScheduleTable.js
@@ -1,63 +1,76 @@
-import React from "react";
+import React from 'react';
 import BootstrapTable from 'react-bootstrap-table-next';
-import { Button } from "react-bootstrap";
-import { useHistory } from "react-router-dom";
+import { Button } from 'react-bootstrap';
+import { useHistory } from 'react-router-dom';
+import { yyyyqToQyy } from 'main/utils/quarterUtilities';
 
 const ScheduleTable = ({ data, deleteSchedule }) => {
-
   const history = useHistory();
   const renderEditButton = (id) => {
     return (
-      <Button data-testid={`edit-button-${id}`} onClick={() => { 
-        history.push(`/schedule/update/${id}`) ;
-      }}>Edit</Button>
-    )
-  }
+      <Button
+        data-testid={`edit-button-${id}`}
+        onClick={() => {
+          history.push(`/schedule/update/${id}`);
+        }}
+      >
+        Edit
+      </Button>
+    );
+  };
 
   const renderDeleteButton = (id) => {
     return (
-      <Button variant="danger" data-testid={`delete-button-${id}`} onClick={() => {
-        return deleteSchedule(id);
-      }}>Delete</Button>
-    )
-  }
+      <Button
+        variant="danger"
+        data-testid={`delete-button-${id}`}
+        onClick={() => {
+          return deleteSchedule(id);
+        }}
+      >
+        Delete
+      </Button>
+    );
+  };
 
-  const columns = [{
-    dataField: 'id',
-    text: 'id'
-  }, {
-    dataField: 'name',
-    text: 'Name',
-    align: "left",
-    headerAlign: "left",
-    formatter: (cell, row) => <a href={"/schedule/" + row.id}> {cell} </a>
-  },
-  {
-    dataField: 'description',
-    text: 'Description',
-    align: "left",
-    headerAlign: "left"
-  },
-  {
-    dataField: 'quarter',
-    text: 'Quarter'
-  },
-  {
-    text: "Edit",
-    isDummyField: true,
-    dataField: "edit",
-    formatter: (_cell, row) => renderEditButton(row.id)
-  }, {
-    text: "Delete",
-    isDummyField: true,
-    dataField: "delete",
-    formatter: (_cell, row) => renderDeleteButton(row.id)
-  }
+  const columns = [
+    {
+      dataField: 'id',
+      text: 'id',
+    },
+    {
+      dataField: 'name',
+      text: 'Name',
+      align: 'left',
+      headerAlign: 'left',
+      formatter: (cell, row) => <a href={'/schedule/' + row.id}> {cell} </a>,
+    },
+    {
+      dataField: 'description',
+      text: 'Description',
+      align: 'left',
+      headerAlign: 'left',
+    },
+    {
+      dataField: 'quarter',
+      text: 'Quarter',
+      formatter: (cell, row) => <p> {yyyyqToQyy(cell)}</p>,
+    },
+    {
+      text: 'Edit',
+      isDummyField: true,
+      dataField: 'edit',
+      formatter: (_cell, row) => renderEditButton(row.id),
+    },
+    {
+      text: 'Delete',
+      isDummyField: true,
+      dataField: 'delete',
+      formatter: (_cell, row) => renderDeleteButton(row.id),
+    },
   ];
 
-  return (
-    <BootstrapTable keyField='id' data={data || []} columns={columns} />
-  );
+  return <BootstrapTable keyField="id" data={data || []} columns={columns} />;
 };
 
 export default ScheduleTable;

--- a/javascript/src/test/components/Schedule/AddSchedForm.test.js
+++ b/javascript/src/test/components/Schedule/AddSchedForm.test.js
@@ -1,86 +1,84 @@
-import React from "react";
-import { render, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import AddSchedForm from "main/components/Schedule/AddSchedForm";
-jest.mock("isomorphic-unfetch");
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AddSchedForm from 'main/components/Schedule/AddSchedForm';
+jest.mock('isomorphic-unfetch');
 
+describe('AddSchedForm tests', () => {
+  test('renders without crashing', () => {
+    render(<AddSchedForm />);
+  });
 
-describe("AddSchedForm tests", () => {
+  test('when I type a name, the state for name changes', () => {
+    const { getByTestId } = render(<AddSchedForm />);
+    const schedName = getByTestId('schedule-name');
+    userEvent.type(schedName, 'My First Schedule');
+    expect(schedName.value).toBe('My First Schedule');
+  });
 
-    test("renders without crashing", () => {
-        render(<AddSchedForm />);
-    });
+  test('when I type a description, the state for description changes', () => {
+    const { getByTestId } = render(<AddSchedForm />);
+    const schedDescription = getByTestId('schedule-description');
+    userEvent.type(schedDescription, 'Classes I want');
+    expect(schedDescription.value).toBe('Classes I want');
+  });
 
-    test("when I type a name, the state for name changes", () => {
-        const { getByTestId } = render(<AddSchedForm />);
-        const schedName = getByTestId("schedule-name")
-        userEvent.type(schedName, "My First Schedule");
-        expect(schedName.value).toBe("My First Schedule");
-    });
+  test('when I choose a quarter, the state for quarter changes', () => {
+    const { getByTestId, getByLabelText } = render(<AddSchedForm />);
+    const schedQuarter = getByLabelText('PersonalScheduleQuarter');
+    userEvent.selectOptions(schedQuarter, '20211');
+    expect(schedQuarter.value).toBe('20211');
+  });
 
-    test("when I type a description, the state for description changes", () => {
-        const { getByTestId } = render(<AddSchedForm />);
-        const schedDescription = getByTestId("schedule-description")
-        userEvent.type(schedDescription, "Classes I want");
-        expect(schedDescription.value).toBe("Classes I want");
-    });
+  test('when I click submit, the right stuff happens', async () => {
+    const sampleReturnValue = {
+      sampleKey: 'sampleValue',
+    };
 
-    test("when I choose a quarter, the state for quarter changes", () => {
-        const { getByTestId } = render(<AddSchedForm />);
-        const schedQuarter = getByTestId("schedule-quarter")
-        userEvent.type(schedQuarter, "F20");
-        expect(schedQuarter.value).toBe("F20");
-    });
+    // Create spy functions (aka jest function, magic function)
+    // The function doesn't have any implementation unless
+    // we specify one.  But it does keep track of whether
+    // it was called, how many times it was called,
+    // and what it was passed.
 
-    test("when I click submit, the right stuff happens", async () => {
+    const fetchJSONSpy = jest.fn();
+    const tokenSpy = 'token';
+    const successSpy = 'success';
+    const errorSpy = 'error';
 
-        const sampleReturnValue = {
-            "sampleKey": "sampleValue"
-        };
+    fetchJSONSpy.mockResolvedValue(sampleReturnValue);
 
-        // Create spy functions (aka jest function, magic function)
-        // The function doesn't have any implementation unless
-        // we specify one.  But it does keep track of whether
-        // it was called, how many times it was called,
-        // and what it was passed.
+    const { getByTestId, getByLabelText } = render(
+      <AddSchedForm
+        createSchedule={fetchJSONSpy}
+        getToken={tokenSpy}
+        onSuccess={successSpy}
+        onError={errorSpy}
+      />
+    );
 
+    const expectedFields = {
+      name: 'MySchedule',
+      description: 'Classes',
+      quarter: '20211',
+      userId: '',
+    };
 
-        const fetchJSONSpy = jest.fn();
-        const tokenSpy = "token";
-        const successSpy = "success";
-        const errorSpy = "error";
+    const schedName = getByTestId('schedule-name');
+    userEvent.type(schedName, 'MySchedule');
+    const schedDescription = getByTestId('schedule-description');
+    userEvent.type(schedDescription, 'Classes');
+    const schedQuarter = getByLabelText('PersonalScheduleQuarter');
+    userEvent.selectOptions(schedQuarter, '20211');
 
-        fetchJSONSpy.mockResolvedValue(sampleReturnValue);
+    const submitButton = getByTestId('schedule-submit');
+    userEvent.click(submitButton);
 
-        const { getByTestId } = render(
-            <AddSchedForm  createSchedule={fetchJSONSpy} getToken={tokenSpy} onSuccess={successSpy} onError={errorSpy} />
-        );
+    // we need to be careful not to assert this expectation
+    // until all of the async promises are resolved
+    await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
 
-        const expectedFields = {
-            name: "MySchedule",
-            description: "Classes",
-            quarter: "F20",
-            userId: ""
-        };
-
-        const schedName = getByTestId("schedule-name")
-        userEvent.type(schedName, "MySchedule");
-        const schedDescription = getByTestId("schedule-description")
-        userEvent.type(schedDescription, "Classes");
-        const schedQuarter = getByTestId("schedule-quarter")
-        userEvent.type(schedQuarter, "F20");
-
-        const submitButton = getByTestId("schedule-submit");
-        userEvent.click(submitButton);
-
-        // we need to be careful not to assert this expectation
-        // until all of the async promises are resolved
-        await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
-
-
-
-        // assert that ourSpy was called with the right value
-        expect(fetchJSONSpy).toHaveBeenCalledWith(expectedFields);
-    });
-
+    // assert that ourSpy was called with the right value
+    expect(fetchJSONSpy).toHaveBeenCalledWith(expectedFields);
+  });
 });

--- a/javascript/src/test/components/Schedule/AddSchedForm.test.js
+++ b/javascript/src/test/components/Schedule/AddSchedForm.test.js
@@ -25,7 +25,7 @@ describe('AddSchedForm tests', () => {
 
   test('when I choose a quarter, the state for quarter changes', () => {
     const { getByTestId, getByLabelText } = render(<AddSchedForm />);
-    const schedQuarter = getByLabelText('PersonalScheduleQuarter');
+    const schedQuarter = getByLabelText('Quarter');
     userEvent.selectOptions(schedQuarter, '20211');
     expect(schedQuarter.value).toBe('20211');
   });
@@ -68,7 +68,7 @@ describe('AddSchedForm tests', () => {
     userEvent.type(schedName, 'MySchedule');
     const schedDescription = getByTestId('schedule-description');
     userEvent.type(schedDescription, 'Classes');
-    const schedQuarter = getByLabelText('PersonalScheduleQuarter');
+    const schedQuarter = getByLabelText('Quarter');
     userEvent.selectOptions(schedQuarter, '20211');
 
     const submitButton = getByTestId('schedule-submit');


### PR DESCRIPTION
As a user, I can select quarter based on a dropdown when creating a personal schedule so that I always choose a quarter that is stored in the database.

Changed AddSchedForm to use the same dropdown as basic courses search. Also, modified schedule table to display converted quarter code to month/year. Eg: 20201 => W20