### PR TITLE
5pm-3-switch basic search and search by course number from a hard coded list of subjects to use selectSubject.

### DIFF
--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
@@ -1,6 +1,11 @@
 import React, { useState } from "react";
 import { Form, Button} from "react-bootstrap";
 import { useToasts } from "react-toast-notifications";
+import SelectSubject from "./SelectSubject";
+import { allTheSubjects } from "main/fixtures/Courses/subjectFixtures";
+import { fetchSubjectAreas } from "main/services/subjectAreaService";
+import useSWR from "swr";
+
 
 const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {
     const [startQuarter, setStartQuarter] = useState("20212");
@@ -9,6 +14,16 @@ const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {
     const [courseNumber, setCourseNumber] = useState("");
     const [courseSuf, setCourseSuf] = useState("");
     const { addToast } = useToasts()
+    const subject = allTheSubjects[0].subjectCode;
+
+    // const { data: subjects, error: errorGettingSubjects } = useSWR(
+	// 	"/api/public/subjects",
+	// 	fetchSubjectAreas,
+	// 	{
+	// 		initialData: allTheSubjects,
+	// 		revalidateOnMount: true,
+	// 	}
+	// );
 
     const handleSubmit = (event) => {
         event.preventDefault();
@@ -28,8 +43,8 @@ const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {
         setEndQuarter(event.target.value);
     };
 
-    const handleSubjectAreaOnChange = (event) => {
-        setSubjectArea(event.target.value);
+    const handleSubjectAreaOnChange = (subject) => {
+        setSubjectArea(subject);
     };
 
     const handleCourseNumberOnChange = (event) => {
@@ -76,102 +91,11 @@ const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {
                     <option value="20201">W20</option>
                 </Form.Control>
             </Form.Group>
-            <Form.Group controlId="CourseNameSearch.SubjectArea">
-                <Form.Label>Subject Area</Form.Label>
-                <Form.Control as="select" onChange={handleSubjectAreaOnChange} value={subjectArea}>
-                    <option value="ANTH    ">ANTH - Anthropology</option>
-                    <option value="ART     ">ART - Art</option>
-                    <option value="ART  CS ">ART - Art (Creative Studies)</option>
-                    <option value="ARTHI   ">ARTHI - Art History</option>
-                    <option value="ARTST   ">ARTST - Art Studio</option>
-                    <option value="AS AM   ">AS AM - Asian American Studies</option>
-                    <option value="ASTRO   ">ASTRO - Astronomy</option>
-                    <option value="BIOL    ">BIOL - Biology</option>
-                    <option value="BIOL CS ">BIOL - Biology (Creative Studies)</option>
-                    <option value="BMSE    ">BMSE - Biomolecular Science and Engineering</option>
-                    <option value="BL ST   ">BL ST - Black Studies</option>
-                    <option value="CH E    ">CH E - Chemical Engineering</option>
-                    <option value="CHEM    ">CHEM - Chemistry and Biochemistry</option>
-                    <option value="CHEM CS ">CHEM - Chemistry and Biochemistry (Creative Studies)</option>
-                    <option value="CH ST   ">CH ST - Chicano Studies</option>
-                    <option value="CHIN    ">CHIN - Chinese</option>
-                    <option value="CLASS   ">CLASS - Classics</option>
-                    <option value="COMM    ">COMM - Communication</option>
-                    <option value="C LIT   ">C LIT - Comparative Literature</option>
-                    <option value="CMPSC   ">CMPSC - Computer Science</option>
-                    <option value="CMPSCCS ">CMPSC - Computer Science (Creative Studies)</option>
-                    <option value="CMPTGCS ">CMPTG - Computing (Creative Studies)</option>
-                    <option value="CNCSP   ">CNCSP - Counseling, Clinical, School Psychology</option>
-                    <option value="DANCE   ">DANCE - Dance</option>
-                    <option value="DYNS    ">DYNS - Dynamical Neuroscience</option>
-                    <option value="EARTH   ">EARTH - Earth Science</option>
-                    <option value="EACS    ">EACS - East Asian Cultural Studies</option>
-                    <option value="EEMB    ">EEMB - Ecology, Evolution, and Marine Biology</option>
-                    <option value="ECON    ">ECON - Economics</option>
-                    <option value="ED      ">ED - Education</option>
-                    <option value="ECE     ">ECE - Electrical Computer Engineering</option>
-                    <option value="ENGR    ">ENGR - Engineering Sciences</option>
-                    <option value="ENGL    ">ENGL - English</option>
-                    <option value="EDS     ">EDS - Environmental Data Science</option>
-                    <option value="ESM     ">ESM - Environmental Science and Management</option>
-                    <option value="ENV S   ">ENV S - Environmental Studies</option>
-                    <option value="ESS     ">ESS - Exercise and Sport Studies</option>
-                    <option value="ES   1- ">ES - Exercise Sport</option>
-                    <option value="FEMST   ">FEMST - Feminist Studies</option>
-                    <option value="FAMST   ">FAMST - Film and Media Studies</option>
-                    <option value="FR      ">FR - French</option>
-                    <option value="GEN SCS ">GEN S - General Studies (Creative Studies)</option>
-                    <option value="GEOG    ">GEOG - Geography</option>
-                    <option value="GER     ">GER - German</option>
-                    <option value="GPS     ">GPS - Global Peace and Security</option>
-                    <option value="GLOBL   ">GLOBL - Global Studies</option>
-                    <option value="GRAD    ">GRAD - Graduate Division</option>
-                    <option value="GREEK   ">GREEK - Greek</option>
-                    <option value="HEB     ">HEB - Hebrew</option>
-                    <option value="HIST    ">HIST - History</option>
-                    <option value="INT     ">INT - Interdisciplinary</option>
-                    <option value="INT  CS ">INT - Interdisciplinary (Creative Studies)</option>
-                    <option value="ITAL    ">ITAL - Italian</option>
-                    <option value="JAPAN   ">JAPAN - Japanese</option>
-                    <option value="KOR     ">KOR - Korean</option>
-                    <option value="LATIN   ">LATIN - Latin</option>
-                    <option value="LAIS    ">LAIS - Latin American and Iberian Studies</option>
-                    <option value="LING    ">LING - Linguistics</option>
-                    <option value="LIT     ">LIT - Literature</option>
-                    <option value="LIT  CS ">LIT - Literature (Creative Studies)</option>
-                    <option value="MARSC   ">MARSC - Marine Science</option>
-                    <option value="MATRL   ">MATRL - Materials</option>
-                    <option value="MATH    ">MATH - Mathematics</option>
-                    <option value="MATH CS ">MATH - Mathematics (Creative Studies)</option>
-                    <option value="ME      ">ME - Mechanical Engineering</option>
-                    <option value="MAT     ">MAT - Media Arts and Technology</option>
-                    <option value="ME ST   ">ME ST - Midieval Studies</option>
-                    <option value="MES     ">MES - Middle East Studies</option>
-                    <option value="MS      ">MS - Military Science</option>
-                    <option value="MCDB    ">MCDB - Molecular, Cellular and Develop. Biology</option>
-                    <option value="MUS     ">MUS - Music</option>
-                    <option value="MUS  CS ">MUS - Music (Creative Studies</option>
-                    <option value="MUS A   ">MUS A - Music Performance Laboratories</option>
-                    <option value="PHIL    ">PHIL - Philosophy</option>
-                    <option value="PHYS    ">PHYS - Physics</option>
-                    <option value="PHYS CS ">PHYS - Physics (Creative Studies)</option>
-                    <option value="POL S   ">POL S - Political Science</option>
-                    <option value="PORT    ">PORT - Portuguese</option>
-                    <option value="PSY     ">PSY - Psychology</option>
-                    <option value="RG ST   ">RG ST - Religious Studies</option>
-                    <option value="RENST   ">RENST - Renaissance Studies</option>
-                    <option value="RUSS    ">RUSS - Russian</option>
-                    <option value="SLAV    ">SLAV - Slavic</option>
-                    <option value="SOC     ">SOC - Sociology</option>
-                    <option value="SPAN    ">SPAN - Spanish</option>
-                    <option value="SHS     ">SHS - Speech and Hearing Sciences</option>
-                    <option value="PSTAT   ">PSTAT - Statistics and Applied Probability</option>
-                    <option value="TMP     ">TMP - Technology Management</option>
-                    <option value="THTR    ">THTR - Theater</option>
-                    <option value="WRIT    ">WRIT - Writing</option>
-                    <option value="W%26L  CS ">W&L - Writing and Literature (Creative Studies)</option>
-                </Form.Control>
-            </Form.Group>
+            <SelectSubject
+				subjects={allTheSubjects}
+				subject={subject}
+				setSubject={handleSubjectAreaOnChange}
+			/>
             <Form.Group controlId="CourseNameSearch.CourseNumber">
                 <Form.Label>Course Number (Try searching '16' or '130A')</Form.Label>
                 <Form.Control onChange={handleCourseNumberOnChange} defaultValue={courseNumber} />

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
@@ -1,11 +1,10 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Form, Button} from "react-bootstrap";
 import { useToasts } from "react-toast-notifications";
 import SelectSubject from "./SelectSubject";
 import { allTheSubjects } from "main/fixtures/Courses/subjectFixtures";
 import { fetchSubjectAreas } from "main/services/subjectAreaService";
 import useSWR from "swr";
-import React, { useState, useEffect } from "react";
 
 
 const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
@@ -14,16 +14,15 @@ const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {
     const [courseNumber, setCourseNumber] = useState("");
     const [courseSuf, setCourseSuf] = useState("");
     const { addToast } = useToasts()
-    const subject = allTheSubjects[0].subjectCode;
 
-    // const { data: subjects, error: errorGettingSubjects } = useSWR(
-	// 	"/api/public/subjects",
-	// 	fetchSubjectAreas,
-	// 	{
-	// 		initialData: allTheSubjects,
-	// 		revalidateOnMount: true,
-	// 	}
-	// );
+    const { data: subjects, error: errorGettingSubjects } = useSWR(
+		"/api/public/subjects",
+		fetchSubjectAreas,
+		{
+			initialData: allTheSubjects,
+			revalidateOnMount: true,
+		}
+	);
 
     const handleSubmit = (event) => {
         event.preventDefault();
@@ -92,8 +91,8 @@ const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {
                 </Form.Control>
             </Form.Group>
             <SelectSubject
-				subjects={allTheSubjects}
-				subject={subject}
+				subjects={subjects}
+				subject={subjectArea}
 				setSubject={handleSubjectAreaOnChange}
 			/>
             <Form.Group controlId="CourseNameSearch.CourseNumber">

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
@@ -24,6 +24,13 @@ const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {
 		}
 	);
 
+    useEffect(() => {
+		if (!errorNotified && errorGettingSubjects) {
+			addToast(`${errorGettingSubjects}`, { appearance: "error" });
+			setErrorNotified(true);
+		}
+	}, [errorGettingSubjects, errorNotified, addToast]);
+
     const handleSubmit = (event) => {
         event.preventDefault();
         fetchJSON(event, { startQuarter, endQuarter, subject, courseNumber, courseSuf}).then((courseJSON) => {

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
@@ -5,6 +5,7 @@ import SelectSubject from "./SelectSubject";
 import { allTheSubjects } from "main/fixtures/Courses/subjectFixtures";
 import { fetchSubjectAreas } from "main/services/subjectAreaService";
 import useSWR from "swr";
+import React, { useState, useEffect } from "react";
 
 
 const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {
@@ -14,6 +15,7 @@ const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {
     const [courseNumber, setCourseNumber] = useState("");
     const [courseSuf, setCourseSuf] = useState("");
     const { addToast } = useToasts()
+    const [errorNotified, setErrorNotified] = useState(false);
 
     const { data: subjects, error: errorGettingSubjects } = useSWR(
 		"/api/public/subjects",

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
@@ -45,14 +45,6 @@ const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {
         });
     };
 
-    const handleStartQuarterOnChange = (event) => {
-        setStartQuarter(event.target.value);
-    };
-
-    const handleEndQuarterOnChange = (event) => {
-        setEndQuarter(event.target.value);
-    };
-
     const handleSubjectOnChange = (subject) => {
         setSubject(subject);
     };

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
@@ -10,7 +10,7 @@ import useSWR from "swr";
 const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {
     const [startQuarter, setStartQuarter] = useState("20212");
     const [endQuarter, setEndQuarter] = useState("20212");
-    const [subjectArea, setSubjectArea] = useState("CMPSC   ");
+    const [subject, setSubject] = useState("CMPSC   ");
     const [courseNumber, setCourseNumber] = useState("");
     const [courseSuf, setCourseSuf] = useState("");
     const { addToast } = useToasts()
@@ -26,7 +26,7 @@ const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {
 
     const handleSubmit = (event) => {
         event.preventDefault();
-        fetchJSON(event, { startQuarter, endQuarter, subjectArea, courseNumber, courseSuf}).then((courseJSON) => {
+        fetchJSON(event, { startQuarter, endQuarter, subject, courseNumber, courseSuf}).then((courseJSON) => {
             if(courseJSON.total === 0){
                 addToast("There are no courses that match the requested criteria.", { appearance: "error" });
             }
@@ -42,8 +42,8 @@ const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {
         setEndQuarter(event.target.value);
     };
 
-    const handleSubjectAreaOnChange = (subject) => {
-        setSubjectArea(subject);
+    const handleSubjectOnChange = (subject) => {
+        setSubject(subject);
     };
 
     const handleCourseNumberOnChange = (event) => {
@@ -92,8 +92,8 @@ const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {
             </Form.Group>
             <SelectSubject
 				subjects={subjects}
-				subject={subjectArea}
-				setSubject={handleSubjectAreaOnChange}
+				subject={subject}
+				setSubject={handleSubjectOnChange}
 			/>
             <Form.Group controlId="CourseNameSearch.CourseNumber">
                 <Form.Label>Course Number (Try searching '16' or '130A')</Form.Label>

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
@@ -26,6 +26,13 @@ const CourseSearchFormQtrDeptOnly = ({ setCourseJSON, fetchJSON }) => {
 		}
 	);
 
+	useEffect(() => {
+		if (!errorNotified && errorGettingSubjects) {
+			addToast(`${errorGettingSubjects}`, { appearance: "error" });
+			setErrorNotified(true);
+		}
+	}, [errorGettingSubjects, errorNotified, addToast]);
+
 	const handleSubmit = (event) => {
 		event.preventDefault();
 		fetchJSON(event, { quarter, subject }).then((courseJSON) => {

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Form, Button } from "react-bootstrap";
 import { useToasts } from "react-toast-notifications";
 import { quarterRange } from "main/utils/quarterUtilities";
@@ -7,7 +7,6 @@ import SelectSubject from "./SelectSubject";
 import { allTheSubjects } from "main/fixtures/Courses/subjectFixtures";
 import { fetchSubjectAreas } from "main/services/subjectAreaService";
 import useSWR from "swr";
-import React, { useState, useEffect } from "react";
 
 const CourseSearchFormQtrDeptOnly = ({ setCourseJSON, fetchJSON }) => {
     const localSearchQuarter = localStorage.getItem("BasicSearchQtrDept.Quarter");

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
@@ -7,6 +7,7 @@ import SelectSubject from "./SelectSubject";
 import { allTheSubjects } from "main/fixtures/Courses/subjectFixtures";
 import { fetchSubjectAreas } from "main/services/subjectAreaService";
 import useSWR from "swr";
+import React, { useState, useEffect } from "react";
 
 const CourseSearchFormQtrDeptOnly = ({ setCourseJSON, fetchJSON }) => {
     const localSearchQuarter = localStorage.getItem("BasicSearchQtrDept.Quarter");
@@ -16,6 +17,7 @@ const CourseSearchFormQtrDeptOnly = ({ setCourseJSON, fetchJSON }) => {
 	const [quarter, setQuarter] = useState(localSearchQuarter || quarters[0].yyyyq);
 	const [subject, setSubject] = useState(localSearchDept || "CMPSC");
 	const { addToast } = useToasts();
+	const [errorNotified, setErrorNotified] = useState(false);
 
 	const { data: subjects, error: errorGettingSubjects } = useSWR(
 		"/api/public/subjects",

--- a/javascript/src/main/services/courseSearches.js
+++ b/javascript/src/main/services/courseSearches.js
@@ -19,7 +19,7 @@ const fetchGeQtrJSON = async (_event, fields) => {
 };
   
 const fetchCourseHistoryNameQtrJSON = async (_event, fields) => {
-    const url = `/api/public/history/coursesearch?startQtr=${fields.startQuarter}&endQtr=${fields.endQuarter}&subjectArea=${fields.subjectArea}&courseNumber=${fields.courseNumber}&courseSuf=${fields.courseSuf}`;
+    const url = `/api/public/history/coursesearch?startQtr=${fields.startQuarter}&endQtr=${fields.endQuarter}&subjectArea=${fields.subject}&courseNumber=${fields.courseNumber}&courseSuf=${fields.courseSuf}`;
     const courseResponse = await fetch(url);
     return courseResponse.json();
 };

--- a/javascript/src/main/services/courseSearches.js
+++ b/javascript/src/main/services/courseSearches.js
@@ -7,7 +7,7 @@ import fetch from "isomorphic-unfetch";
 };
 
 const fetchBasicCourseHistoryJSON = async (_event, fields) => {
-    const url = `/api/public/history/basicsearch?qtr=${fields.quarter}&dept=${fields.department}`;
+    const url = `/api/public/history/basicsearch?qtr=${fields.quarter}&dept=${fields.subject}`;
     const courseResponse = await fetch(url);
     return courseResponse.json();
 };

--- a/javascript/src/test/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.test.js
+++ b/javascript/src/test/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.test.js
@@ -87,7 +87,7 @@ describe("CourseSearchCourseStartEndQtr tests", () => {
         const expectedFields = {
             startQuarter: "20204",
             endQuarter: "20204",
-            subjectArea: "CMPSC",
+            subject: "CMPSC",
             courseNumber: "130",
             courseSuf: "A"
         };
@@ -195,7 +195,7 @@ describe("CourseSearchCourseStartEndQtr tests", () => {
         const cs138Fields = {
             startQuarter: "20204",
             endQuarter: "20204",
-            subjectArea: "CMPSC",
+            subject: "CMPSC",
             courseNumber: "138",
             courseSuf: ""
         };

--- a/javascript/src/test/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.test.js
+++ b/javascript/src/test/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.test.js
@@ -38,8 +38,8 @@ describe("CourseSearchCourseStartEndQtr tests", () => {
     test("when I select a subject area, the state for subject area changes", () => {
         const { getByLabelText } = render(<CourseSearchCourseStartEndQtr />);
         const SelectSubject = getByLabelText("Subject Area")
-        userEvent.selectOptions(SelectSubject, "MATH    ");
-        expect(SelectSubject.value).toBe("MATH    ");
+        userEvent.selectOptions(SelectSubject, "MATH");
+        expect(SelectSubject.value).toBe("MATH");
     });
 
     test("when I select a course number without suffix, the state for course number changes,", () => {
@@ -87,7 +87,7 @@ describe("CourseSearchCourseStartEndQtr tests", () => {
         const expectedFields = {
             startQuarter: "20204",
             endQuarter: "20204",
-            subjectArea: "CMPSC   ",
+            subjectArea: "CMPSC",
             courseNumber: "130",
             courseSuf: "A"
         };
@@ -97,7 +97,7 @@ describe("CourseSearchCourseStartEndQtr tests", () => {
         const selectEndQuarter = getByLabelText("End Quarter")
         userEvent.selectOptions(selectEndQuarter, "20204");
         const SelectSubject = getByLabelText("Subject Area")
-        userEvent.selectOptions(SelectSubject, "CMPSC   ");
+        userEvent.selectOptions(SelectSubject, "CMPSC");
         const selectCourseNumber = getByLabelText("Course Number (Try searching '16' or '130A')")
         userEvent.type(selectCourseNumber, "130A  ");
 
@@ -141,7 +141,7 @@ describe("CourseSearchCourseStartEndQtr tests", () => {
         const selectEndQuarter = getByLabelText("End Quarter")
         userEvent.selectOptions(selectEndQuarter, "20204");
         const SelectSubject = getByLabelText("Subject Area")
-        userEvent.selectOptions(SelectSubject, "CMPSC   ");
+        userEvent.selectOptions(SelectSubject, "CMPSC");
         const selectCourseNumber = getByLabelText("Course Number (Try searching '16' or '130A')")
         userEvent.type(selectCourseNumber, "130A  ");
 
@@ -179,7 +179,7 @@ describe("CourseSearchCourseStartEndQtr tests", () => {
         const selectEndQuarter = getByLabelText("End Quarter")
         userEvent.selectOptions(selectEndQuarter, "20204");
         const SelectSubject = getByLabelText("Subject Area")
-        userEvent.selectOptions(SelectSubject, "CMPSC   ");
+        userEvent.selectOptions(SelectSubject, "CMPSC");
         const selectCourseNumber = getByLabelText("Course Number (Try searching '16' or '130A')")
         userEvent.type(selectCourseNumber, "130A  ");
 
@@ -195,7 +195,7 @@ describe("CourseSearchCourseStartEndQtr tests", () => {
         const cs138Fields = {
             startQuarter: "20204",
             endQuarter: "20204",
-            subjectArea: "CMPSC   ",
+            subjectArea: "CMPSC",
             courseNumber: "138",
             courseSuf: ""
         };

--- a/javascript/src/test/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.test.js
+++ b/javascript/src/test/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.test.js
@@ -59,7 +59,7 @@ describe("CourseSearchFormQtrDeptOnly tests", () => {
 
         const expectedFields = {
             quarter: "20204",
-            department: "MATH"
+            subject: "MATH"
         };
 
         const selectQuarter = getByLabelText("Quarter")

--- a/javascript/src/test/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.test.js
+++ b/javascript/src/test/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.test.js
@@ -64,8 +64,8 @@ describe("CourseSearchFormQtrDeptOnly tests", () => {
 
         const selectQuarter = getByLabelText("Quarter")
         userEvent.selectOptions(selectQuarter, "20204");
-        const selectDepartment = getByLabelText("Department")
-        userEvent.selectOptions(selectDepartment, "MATH");
+        const selectSubject = getByLabelText("Subject Area")
+        userEvent.selectOptions(selectSubject, "MATH");
     
 
         const submitButton = getByText("Submit");
@@ -106,8 +106,8 @@ describe("CourseSearchFormQtrDeptOnly tests", () => {
 
         const selectQuarter = getByLabelText("Quarter")
         userEvent.selectOptions(selectQuarter, "20204");
-        const selectDepartment = getByLabelText("Department")
-        userEvent.selectOptions(selectDepartment, "MATH");
+        const selectSubject = getByLabelText("Subject Area")
+        userEvent.selectOptions(selectSubject, "MATH");
     
 
         const submitButton = getByText("Submit");

--- a/javascript/src/test/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.test.js
+++ b/javascript/src/test/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.test.js
@@ -28,11 +28,11 @@ describe("CourseSearchFormQtrDeptOnly tests", () => {
         expect(selectQuarter.value).toBe("20204");
     });
 
-    test("when I select a department, the state for department changes", () => {
+    test("when I select a subject, the state for subject changes", () => {
         const { getByLabelText } = render(<CourseSearchFormQtrDeptOnly />);
-        const selectDepartment = getByLabelText("Department")
-        userEvent.selectOptions(selectDepartment, "MATH");
-        expect(selectDepartment.value).toBe("MATH");
+        const selectSubject = getByLabelText("Subject Area")
+        userEvent.selectOptions(selectSubject, "ARTHI");
+        expect(selectSubject.value).toBe("ARTHI");
     });
 
    

--- a/javascript/src/test/services/courseSearches.test.js
+++ b/javascript/src/test/services/courseSearches.test.js
@@ -76,7 +76,7 @@ describe("courseSearches tests",  () => {
     };
 
     const result = await fetchCourseHistoryNameQtrJSON({},expectedFields);
-    expect(fetch).toHaveBeenCalledWith(`/api/public/history/coursesearch?startQtr=${expectedFields.startQuarter}&endQtr=${expectedFields.endQuarter}&subjectArea=${expectedFields.subjectArea}&courseNumber=${expectedFields.courseNumber}&courseSuf=${expectedFields.courseSuf}`)
+    expect(fetch).toHaveBeenCalledWith(`/api/public/history/coursesearch?startQtr=${expectedFields.startQuarter}&endQtr=${expectedFields.endQuarter}&subjectArea=${expectedFields.subject}&courseNumber=${expectedFields.courseNumber}&courseSuf=${expectedFields.courseSuf}`)
     expect(result).toBe(sampleReturnValue);
 
   });


### PR DESCRIPTION
Previously when users wanted to select a subject on both the basic search and search by course number, they only had the option to search from a list of hard coded subjects. We implemented the selectSubject for both of these searches so users will now have a complete catalog of subjects to search from. 

- Basic search will only work for CMPSC and MATH because the backend is not working for other subjects.