### PR TITLE
pc - update final quarter in UX

### DIFF
--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -10,7 +10,7 @@ import SelectQuarter from "main/components/BasicCourseSearch/SelectQuarter";
 import SelectLevel from "main/components/BasicCourseSearch/SelectLevel";
 
 const BasicCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
-	const quarters = quarterRange("20084", "20214");
+	const quarters = quarterRange("20084", "20224");
 	const levels = [["L","Undergrad-Lower"], 
 					["S","Undergrad-Upper Division"], 
 					["U","Undergrad-All"], 

--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseTable.js
@@ -12,7 +12,8 @@ import moment from 'moment';
 
 const BasicCourseTable = ({ classes, checks, displayQuarter, allowExport }) => {
   const { isAuthenticated } = useAuth0();
-  const sections = reformatJSON(classes, checks);
+  
+  const sections = (classes && checks) ? reformatJSON(classes, checks) : [];
 
   const CLOSEFULL_THRESHOLD=0.2;
   const classUnavailable = (row) => (row.enrolledTotal >= row.maxEnroll || row.courseCancelled === "Y" || row.classClosed ==="Y"); 

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
@@ -10,7 +10,7 @@ import useSWR from "swr";
 
 
 const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {
-    const quarters = quarterRange("20084", "20213");
+    const quarters = quarterRange("20084", "20224");
     const [startQuarter, setStartQuarter] = useState(quarters[0].qqqqy);
     const [endQuarter, setEndQuarter] = useState(quarters[0].qqqqy);
     const [subject, setSubject] = useState("CMPSC   ");

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchFormInstructor.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchFormInstructor.js
@@ -6,7 +6,7 @@ import SelectQuarter from "main/components/BasicCourseSearch/SelectQuarter";
 
 const CourseSearchFormInstructor = ({ setCourseJSON, fetchJSON }) => {
 
-    const quarters = quarterRange("20084", "20213");
+    const quarters = quarterRange("20084", "20224");
 
     const [startQuarter, setStartQuarter] = useState(quarters[0].qqqqy);
     const [endQuarter, setEndQuarter] = useState(quarters[0].qqqqy);

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
@@ -12,7 +12,7 @@ const CourseSearchFormQtrDeptOnly = ({ setCourseJSON, fetchJSON }) => {
     const localSearchQuarter = localStorage.getItem("BasicSearchQtrDept.Quarter");
     const localSearchDept = localStorage.getItem("BasicSearchQtrDept.Subject");
 
-	const quarters = quarterRange("20084", "20213");
+	const quarters = quarterRange("20084", "20224");
 	const [quarter, setQuarter] = useState(localSearchQuarter || quarters[0].yyyyq);
 	const [subject, setSubject] = useState(localSearchDept || "CMPSC");
 	const { addToast } = useToasts();

--- a/javascript/src/main/components/BasicCourseSearch/GeCourseSearchForm.js
+++ b/javascript/src/main/components/BasicCourseSearch/GeCourseSearchForm.js
@@ -5,7 +5,7 @@ import { quarterRange } from "main/utils/quarterUtilities";
 import SelectQuarter from "main/components/BasicCourseSearch/SelectQuarter";
 
 const GeCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
-    const quarters = quarterRange("20084", "20213");
+    const quarters = quarterRange("20084", "20224");
     const [startQuarter, setStartQuarter] = useState(quarters[0].qqqqy);
     const [endQuarter, setEndQuarter] = useState(quarters[0].qqqqy);
     const [geCode, setGeCode] = useState("A1 ");

--- a/javascript/src/main/components/Schedule/AddSchedForm.js
+++ b/javascript/src/main/components/Schedule/AddSchedForm.js
@@ -13,7 +13,7 @@ const AddSchedForm = ({ createSchedule, updateSchedule, existingSchedule }) => {
   };
 
   const [schedule, setSchedule] = useState(existingSchedule || emptySchedule);
-  const quarters = quarterRange('20084', '20214');
+  const quarters = quarterRange('20084', '20224');
   const [quarter, setQuarter] = useState(
     existingSchedule ? existingSchedule.quarter : emptySchedule.quarter
   );


### PR DESCRIPTION
In this PR, we update the final quarter for as many UX elements as we can find to be F22.

In future versions of the code base, it would be great if the first and last quarters for the quarter selectors were a settable property that could be overridden at runtime with configuration.

I'm hoping that extending to F22 will give us plenty of time to move features to the new app so that this one can be retired by F22.

