### PR TITLE
pc - add github action to manually trigger building the storybook in -docs repo

### DIFF
--- a/.github/workflows/00-manually-publish-storybook.yml
+++ b/.github/workflows/00-manually-publish-storybook.yml
@@ -1,0 +1,53 @@
+name: Publish 02 docs (Storybook) to GitHub Pages
+on: 
+  workflow_dispatch:
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+      - name: Append name of site to _config.yml
+        working-directory: ./javascript/docs-index
+        run: | 
+          OWNER_PLUS_REPOSITORY=${{github.repository}}
+          OWNER=${{ github.repository_owner }}
+          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
+          echo "repo: ${OWNER_PLUS_REPOSITORY}" >> _config.yml
+          echo "owner: ${OWNER}" >> _config.yml
+          echo "repo_name: ${REPOSITORY}" >> _config.yml
+      - name: Deploy index.md and jekyll files for production docs site 🚀
+        uses: JamesIves/github-pages-deploy-action@4.2.0
+        with:
+          repository-name: ${{ github.repository }}-docs
+          token: ${{ secrets.DOCS_TOKEN }}
+          branch: main # The branch the action should deploy to.
+          folder: javascript/docs-index 
+          clean: false 
+          target-folder: docs
+      - name: Deploy index.md for docs site 🚀
+        uses: JamesIves/github-pages-deploy-action@4.2.0
+        with:
+          repository-name: ${{ github.repository }}-docs
+          token: ${{ secrets.DOCS_TOKEN }}
+          branch: main # The branch the action should deploy to.
+          folder: javascript/docs-index 
+          clean: true 
+          target-folder: docs
+      - name: Install and Build 🔧
+        working-directory: ./javascript
+        run: | # Install npm packages and build the Storybook files
+          npm install
+          mkdir -p docs-build
+          npm run build-storybook
+      - name: Deploy 🚀 
+        uses: JamesIves/github-pages-deploy-action@4.2.0
+        with:
+          repository-name: ${{ github.repository }}-docs
+          token: ${{ secrets.DOCS_TOKEN }}
+          branch: main # The branch the action should deploy to.
+          folder: javascript/storybook-static # The folder that the build-storybook script generates files.
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: docs/storybook # The folder that we serve our Storybook files from  

--- a/javascript/docs-index/_config.yml
+++ b/javascript/docs-index/_config.yml
@@ -1,0 +1,22 @@
+
+title: QA Site for Documentation
+description: >- # this means to ignore newlines until "baseurl:"
+  When reviewing a PR for this repo, you can see what the documentation,
+  e.g. the storybook, will look like when published for the branches
+  named above.
+baseurl: "" # the subpath of your site, e.g. /blog
+url: "" # the base hostname & protocol for your site, e.g. http://example.com
+
+repo_name: "This-should-be-overridden-by-github-actions-script"
+
+# Build settings
+theme: minima
+plugins:
+  - jekyll-feed
+
+collections:
+  branches:
+    output: true
+    permalink: /branches/:path/
+
+repo_name: "This-should-be-overridden-by-github-actions-script"

--- a/javascript/docs-index/_layouts/default.html
+++ b/javascript/docs-index/_layouts/default.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ page.title }}</title>
+    <link rel="stylesheet" href="/{{site.repo_name}}/css/style.css">
+  </head>
+  <body>
+    <h1>{{site.repo_name}}-qa-docs</h1>
+    <section>
+      {{ content }}
+    </section>
+    <footer>
+    </footer>
+  </body>
+</html>

--- a/javascript/docs-index/index.md
+++ b/javascript/docs-index/index.md
@@ -1,0 +1,9 @@
+# Links 
+
+* Source Repo: <https://github.com/{{site.repo}}>
+* Production Docs Repo: <https://github.com/{{site.repo}}-docs>
+
+
+# Documentation
+
+* [Storybook](storybook)


### PR DESCRIPTION
In this PR, we add a Github Actions Workflow that is only triggered by manually running it, i.e.

```
on:
  workflow_dispatch:
```

It populates the `-docs` repo with the storybook.