### PR TITLE
pc - adjust end quarter to be F22

### DIFF
--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -10,7 +10,7 @@ import SelectQuarter from "main/components/BasicCourseSearch/SelectQuarter";
 import SelectLevel from "main/components/BasicCourseSearch/SelectLevel";
 
 const BasicCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
-	const quarters = quarterRange("20084", "20222");
+	const quarters = quarterRange("20084", "20224");
 	const levels = [["L","Undergrad-Lower"], 
 					["S","Undergrad-Upper Division"], 
 					["U","Undergrad-All"], 

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchCourseStartEndQtr.js
@@ -10,7 +10,7 @@ import useSWR from "swr";
 
 
 const CourseSearchCourseStartEndQtr = ({ setCourseJSON, fetchJSON }) => {
-    const quarters = quarterRange("20084", "20222");
+    const quarters = quarterRange("20084", "20224");
     const [startQuarter, setStartQuarter] = useState(quarters[0].qqqqy);
     const [endQuarter, setEndQuarter] = useState(quarters[0].qqqqy);
     const [subject, setSubject] = useState("CMPSC   ");

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchFormInstructor.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchFormInstructor.js
@@ -6,7 +6,7 @@ import SelectQuarter from "main/components/BasicCourseSearch/SelectQuarter";
 
 const CourseSearchFormInstructor = ({ setCourseJSON, fetchJSON }) => {
 
-    const quarters = quarterRange("20084", "20222");
+    const quarters = quarterRange("20084", "20224");
 
     const [startQuarter, setStartQuarter] = useState(quarters[0].qqqqy);
     const [endQuarter, setEndQuarter] = useState(quarters[0].qqqqy);

--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchFormQtrDeptOnly.js
@@ -12,7 +12,7 @@ const CourseSearchFormQtrDeptOnly = ({ setCourseJSON, fetchJSON }) => {
     const localSearchQuarter = localStorage.getItem("BasicSearchQtrDept.Quarter");
     const localSearchDept = localStorage.getItem("BasicSearchQtrDept.Subject");
 
-	const quarters = quarterRange("20084", "20222");
+	const quarters = quarterRange("20084", "20224");
 	const [quarter, setQuarter] = useState(localSearchQuarter || quarters[0].yyyyq);
 	const [subject, setSubject] = useState(localSearchDept || "CMPSC");
 	const { addToast } = useToasts();

--- a/javascript/src/main/components/BasicCourseSearch/GeCourseSearchForm.js
+++ b/javascript/src/main/components/BasicCourseSearch/GeCourseSearchForm.js
@@ -5,7 +5,7 @@ import { quarterRange } from "main/utils/quarterUtilities";
 import SelectQuarter from "main/components/BasicCourseSearch/SelectQuarter";
 
 const GeCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
-    const quarters = quarterRange("20084", "20222");
+    const quarters = quarterRange("20084", "20224");
     const [startQuarter, setStartQuarter] = useState(quarters[0].qqqqy);
     const [endQuarter, setEndQuarter] = useState(quarters[0].qqqqy);
     const [geCode, setGeCode] = useState("A1 ");

--- a/javascript/src/main/components/Schedule/AddSchedForm.js
+++ b/javascript/src/main/components/Schedule/AddSchedForm.js
@@ -13,7 +13,7 @@ const AddSchedForm = ({ createSchedule, updateSchedule, existingSchedule }) => {
   };
 
   const [schedule, setSchedule] = useState(existingSchedule || emptySchedule);
-  const quarters = quarterRange('20084', '20222');
+  const quarters = quarterRange('20084', '20224');
   const [quarter, setQuarter] = useState(
     existingSchedule ? existingSchedule.quarter : emptySchedule.quarter
   );


### PR DESCRIPTION
In this PR, we add M22 and F22 to the various quarter selectors.

For Example, note the M22 and F22 appears in the selector (they did not before this PR):

<img width="1182" alt="image" src="https://user-images.githubusercontent.com/1119017/167205503-ce7159da-05af-4a37-a587-3d6d1bcd65c2.png">

Future work (not in the PR) should involve setting up the start and end quarters as application specific properties that can be set through the `application.properties` file (for example).  

Ideally, the start and end quarters  could be set by a run time environment variable, with appropriate defaults/fallbacks for test/development instances of the app, so that code changes are not required to update these values.
